### PR TITLE
Feature/notification sound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,12 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# JSON file containing dict of member IDs and local audio file paths
+sounds.json 
+
+# Custom notification .mp3s
+.mp3
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN")
+BOT_USER_ID = int(os.getenv("BOT_USER_ID"))
 TEST_CHANNEL_ID = int(os.getenv("TEST_CHANNEL_ID"))
 
 intents = discord.Intents.all()
@@ -17,15 +18,51 @@ async def on_ready():
     channel = bot.get_channel(TEST_CHANNEL_ID)
     await channel.send('running...')
 
-#message user's current voice channel upon deafen or mute with their username and status eg 'username muted'
+#handle voice state changes 
 @bot.event
 async def on_voice_state_update(member, before, after):
-    channel = after.channel
+    voice_client = discord.utils.get(bot.voice_clients, guild=member.guild)
+
+    #if a member joins a channel and the bot has not already joined any channel
+    if after.channel and not voice_client:
+        await after.channel.connect()
+        print("connected to vc")
+    
+    #if a member moves from one channel to another and the new channel has more members, the bot will follow
+    elif voice_client and before.channel and after.channel and after.channel != before.channel and len(after.channel.members) >= len(before.channel.members):
+        await voice_client.disconnect()
+        await after.channel.connect()
+        print("changed vc")
+
+    #if the bot is the sole remaining member in a channel, disconnect 
+    elif voice_client and len(voice_client.channel.members) == 1:
+        await voice_client.disconnect()
+        print("disconnected from vc")
+    
+    #if bot has just disconnected from a channel, check if any other channels have members and join the most populous
+    elif member.id == BOT_USER_ID and not voice_client:
+        print("checking for active vc...")
+        if not member.guild.voice_channels:
+            print("no vc found") #works for now, axpand to notify the user later
+            return
+        most_pop_vc = member.guild.voice_channels[0]
+        for vc in member.guild.voice_channels:
+            if len(vc.members) > len(most_pop_vc.members):
+                most_pop_vc = vc
+        if len(most_pop_vc.members) > 0:
+            await most_pop_vc.connect()
+            print("reconnected to vc")
+        else:
+            print("no active vc")
+
+    #if user has deafened themselves message user's current voice channel with their username and status eg 'username deafened'
     if before.self_deaf == False and after.self_deaf == True:
+        await after.channel.send(str(member) + " deafened")
         print(str(member) + " deafened")
-        await channel.send(str(member) + " deafened")
+
+    #if user has muted themselves message user's current voice channel with their username and status eg 'username muted'
     elif before.self_mute == False and after.self_mute == True:
+        await after.channel.send(str(member) + " muted")
         print(str(member) + " muted")
-        await channel.send(str(member) + " muted")
 
 bot.run(BOT_TOKEN)

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -50,12 +50,12 @@ async def on_voice_state_update(member, before, after):
             print(str(member) + " muted")
 
         #if a member joins a channel and the bot has not already joined any channel, join channel
-        if not voice_client and after.channel:
+        elif not voice_client and after.channel:
             await after.channel.connect()
             print("connected to vc")
         
         #if a member moves from one channel to another and the new channel has more members, the bot will follow
-        elif voice_client and after.channel and len(after.channel.members) >= len(voice_client.channel.members):
+        elif voice_client and after.channel and before.channel != after.channel and len(after.channel.members) >= len(voice_client.channel.members):
             # await member.guild.voice_client.move_to(after.channel)
             await voice_client.move_to(after.channel)
             print("changed vc")

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -34,50 +34,51 @@ async def on_ready():
 #handle voice state changes 
 @bot.event
 async def on_voice_state_update(member, before, after):
-    voice_client = discord.utils.get(bot.voice_clients, guild=member.guild)
+    voice_client = member.guild.voice_client
 
-    #if a member joins a channel and the bot has not already joined any channel, join channel
-    if after.channel and not voice_client:
-        await after.channel.connect()
-        print("connected to vc")
-    
-    #if a member moves from one channel to another and the new channel has more members, the bot will follow
-    elif voice_client and before.channel and after.channel and after.channel != before.channel and len(after.channel.members) >= len(before.channel.members):
-        await voice_client.disconnect()
-        await after.channel.connect()
-        print("changed vc")
+    if member.id != BOT_USER_ID:
+        #if user has deafened themselves message user's current voice channel with their username and status eg 'username deafened'
+        if before.self_deaf == False and after.self_deaf == True:
+            await play(voice_client)
+            await after.channel.send(str(member) + " deafened")
+            print(str(member) + " deafened")
 
-    #if the bot is the sole remaining member in a channel, disconnect 
-    elif voice_client and len(voice_client.channel.members) == 1:
-        await voice_client.disconnect()
-        print("disconnected from vc")
-    
-    #if bot has just disconnected from a channel, check if any other channels have members and join the most populous
-    elif member.id == BOT_USER_ID and not voice_client:
-        print("checking for active vc...")
-        if not member.guild.voice_channels:
-            print("no vc found") #works for now, expand to notify the user later
-            return
-        most_pop_vc = member.guild.voice_channels[0]
-        for vc in member.guild.voice_channels:
-            if len(vc.members) > len(most_pop_vc.members):
-                most_pop_vc = vc
-        if len(most_pop_vc.members) > 0:
-            await most_pop_vc.connect()
-            print("reconnected to vc")
-        else:
-            print("no active vc")
+        #if user has muted themselves message user's current voice channel with their username and status eg 'username muted'
+        elif before.self_mute == False and after.self_mute == True:
+            await play(voice_client)
+            await after.channel.send(str(member) + " muted")
+            print(str(member) + " muted")
 
-    #if user has deafened themselves message user's current voice channel with their username and status eg 'username deafened'
-    if before.self_deaf == False and after.self_deaf == True:
-        await play(voice_client)
-        await after.channel.send(str(member) + " deafened")
-        print(str(member) + " deafened")
-
-    #if user has muted themselves message user's current voice channel with their username and status eg 'username muted'
-    elif before.self_mute == False and after.self_mute == True:
-        await play(voice_client)
-        await after.channel.send(str(member) + " muted")
-        print(str(member) + " muted")
+        #if a member joins a channel and the bot has not already joined any channel, join channel
+        if not voice_client and after.channel:
+            await after.channel.connect()
+            print("connected to vc")
+        
+        #if a member moves from one channel to another and the new channel has more members, the bot will follow
+        elif voice_client and after.channel and len(after.channel.members) >= len(voice_client.channel.members):
+            # await member.guild.voice_client.move_to(after.channel)
+            await voice_client.move_to(after.channel)
+            print("changed vc")
+        
+        #if the bot is the sole remaining member in a channel, disconnect 
+        elif voice_client and len(voice_client.channel.members) == 1:
+            await voice_client.disconnect()
+            print("disconnected from vc")
+    else:
+        #if bot has just disconnected from a channel, check if any other channels have members and join the most populous
+        if not voice_client:
+            print("checking for active vc...")
+            if not member.guild.voice_channels:
+                print("no vc found") #works for now, expand to notify the user later
+                return
+            most_pop_vc = member.guild.voice_channels[0]
+            for vc in member.guild.voice_channels:
+                if len(vc.members) > len(most_pop_vc.members):
+                    most_pop_vc = vc
+            if len(most_pop_vc.members) > 0:
+                await most_pop_vc.connect()
+                print("reconnected to vc")
+            else:
+                print("no active vc")
 
 bot.run(BOT_TOKEN)

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -34,18 +34,21 @@ async def on_ready():
 #handle voice state changes 
 @bot.event
 async def on_voice_state_update(member, before, after):
-    voice_client = member.guild.voice_client
+    voice_client = discord.utils.get(bot.voice_clients, guild = member.guild)
+
+    def is_connected():
+        return voice_client and voice_client.is_connected()
 
     if member.id != BOT_USER_ID:
         #if user has deafened themselves and is in the same vc as the bot, message user's current voice channel with their username and status eg 'username deafened'
-        if before.self_deaf == False and after.self_deaf == True and voice_client.channel == after.channel:
+        if is_connected() and before.self_deaf == False and after.self_deaf == True and voice_client.channel == after.channel:
             await play(voice_client)
             message = f'{member} deafened'
             await after.channel.send(message)
             print(message)
 
         #if user has muted themselves and is in the same vc as the bot, message user's current voice channel with their username and status eg 'username muted'
-        elif before.self_mute == False and after.self_mute == True and voice_client.channel == after.channel:
+        elif is_connected() and before.self_mute == False and after.self_mute == True and voice_client.channel == after.channel:
             await play(voice_client)
             message = f'{member} muted'
             await after.channel.send(message)

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -30,14 +30,12 @@ async def play(voice_client, member, status):
     if not voice_client.is_playing():
         voice_client.play(audio_source, after=None)
     else:
-        print('already playing audio, retrying...')
         time.sleep(2)
         await play(voice_client, member, status)
 
 #message test channel on launch
 @bot.event
 async def on_ready():
-    print('running...')
     channel = bot.get_channel(TEST_CHANNEL_ID)
     await channel.send('running...')
 
@@ -56,7 +54,6 @@ async def on_voice_state_update(member, before, after):
             await play(voice_client, member, 'mute')
             message = f'{member} {mute_type}'
             await after.channel.send(message)
-            print(message)
 
     if member.id != BOT_USER_ID:
         #if user has deafened themselves
@@ -70,40 +67,31 @@ async def on_voice_state_update(member, before, after):
         #if a user joins the channel that the bot is in, play join sound
         elif voice_client and after.channel and after.channel == voice_client.channel and before.channel != after.channel:
             await play(voice_client, member, 'join')
-            print(str(member) + " joined")
 
         #if a member joins a channel and the bot has not already joined any channel, join channel
         elif not voice_client and after.channel:
             await after.channel.connect()
-            print('connected to vc')
         
         #if a member moves from one channel to another and the new channel has more members, the bot will follow
         elif voice_client and after.channel and before.channel != after.channel and len(after.channel.members) >= len(voice_client.channel.members):
             await voice_client.move_to(after.channel)
-            print('changed vc')
         
         #if the bot is the sole remaining member in a channel, disconnect 
         elif voice_client and len(voice_client.channel.members) == 1:
             await voice_client.disconnect()
-            print('disconnected from vc')
         
         #if a user leaves the channel that the bot is in, play leave sound
         elif voice_client and before.channel and before.channel == voice_client.channel and after.channel != voice_client.channel:
             await play(voice_client, member, 'leave')
-            print(str(member) + " left")
     else:
         #if bot has just disconnected from a channel, check if any other channels have members and join the most populous
         if not voice_client:
-            print('checking for active vc...')
             most_pop_vc = member.guild.voice_channels[0]
             for vc in member.guild.voice_channels:
                 if len(vc.members) > len(most_pop_vc.members):
                     most_pop_vc = vc
             if len(most_pop_vc.members) > 0:
                 await most_pop_vc.connect()
-                print('reconnected to vc')
-            else:
-                print('no active vc')
 
 #custom sound paths for certain Discord members are stored in a .json file
 custom_sounds = json.load(open(get_path(CUSTOM_SOUNDS_PATH)))

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -37,14 +37,14 @@ async def on_voice_state_update(member, before, after):
     voice_client = member.guild.voice_client
 
     if member.id != BOT_USER_ID:
-        #if user has deafened themselves message user's current voice channel with their username and status eg 'username deafened'
-        if before.self_deaf == False and after.self_deaf == True:
+        #if user has deafened themselves and is in the same vc as the bot, message user's current voice channel with their username and status eg 'username deafened'
+        if before.self_deaf == False and after.self_deaf == True and voice_client.channel == after.channel:
             await play(voice_client)
             await after.channel.send(str(member) + " deafened")
             print(str(member) + " deafened")
 
-        #if user has muted themselves message user's current voice channel with their username and status eg 'username muted'
-        elif before.self_mute == False and after.self_mute == True:
+        #if user has muted themselves and is in the same vc as the bot, message user's current voice channel with their username and status eg 'username muted'
+        elif before.self_mute == False and after.self_mute == True and voice_client.channel == after.channel:
             await play(voice_client)
             await after.channel.send(str(member) + " muted")
             print(str(member) + " muted")

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -5,11 +5,11 @@ from dotenv import load_dotenv
 import time
 
 load_dotenv()
-BOT_TOKEN = os.getenv("BOT_TOKEN")
-BOT_USER_ID = int(os.getenv("BOT_USER_ID"))
-TEST_CHANNEL_ID = int(os.getenv("TEST_CHANNEL_ID"))
-FFMPEG_PATH = os.getenv("FFMPEG_PATH")
-SOUND_PATH = os.getenv("SOUND_PATH")
+BOT_TOKEN = os.getenv('BOT_TOKEN')
+BOT_USER_ID = int(os.getenv('BOT_USER_ID'))
+TEST_CHANNEL_ID = int(os.getenv('TEST_CHANNEL_ID'))
+FFMPEG_PATH = os.getenv('FFMPEG_PATH')
+SOUND_PATH = os.getenv('SOUND_PATH')
 
 intents = discord.Intents.all()
 bot = commands.Bot(command_prefix='!', intents=intents, case_insensitive=False)
@@ -20,7 +20,7 @@ async def play(voice_client):
     if not voice_client.is_playing():
         voice_client.play(audio_source, after=None)
     else:
-        print("already playing audio, retrying...")
+        print('already playing audio, retrying...')
         time.sleep(2)
         await play(voice_client)
 
@@ -40,36 +40,38 @@ async def on_voice_state_update(member, before, after):
         #if user has deafened themselves and is in the same vc as the bot, message user's current voice channel with their username and status eg 'username deafened'
         if before.self_deaf == False and after.self_deaf == True and voice_client.channel == after.channel:
             await play(voice_client)
-            await after.channel.send(str(member) + " deafened")
-            print(str(member) + " deafened")
+            message = f'{member} deafened'
+            await after.channel.send(message)
+            print(message)
 
         #if user has muted themselves and is in the same vc as the bot, message user's current voice channel with their username and status eg 'username muted'
         elif before.self_mute == False and after.self_mute == True and voice_client.channel == after.channel:
             await play(voice_client)
-            await after.channel.send(str(member) + " muted")
-            print(str(member) + " muted")
+            message = f'{member} muted'
+            await after.channel.send(message)
+            print(message)
 
         #if a member joins a channel and the bot has not already joined any channel, join channel
         elif not voice_client and after.channel:
             await after.channel.connect()
-            print("connected to vc")
+            print('connected to vc')
         
         #if a member moves from one channel to another and the new channel has more members, the bot will follow
         elif voice_client and after.channel and before.channel != after.channel and len(after.channel.members) >= len(voice_client.channel.members):
             # await member.guild.voice_client.move_to(after.channel)
             await voice_client.move_to(after.channel)
-            print("changed vc")
+            print('changed vc')
         
         #if the bot is the sole remaining member in a channel, disconnect 
         elif voice_client and len(voice_client.channel.members) == 1:
             await voice_client.disconnect()
-            print("disconnected from vc")
+            print('disconnected from vc')
     else:
         #if bot has just disconnected from a channel, check if any other channels have members and join the most populous
         if not voice_client:
-            print("checking for active vc...")
+            print('checking for active vc...')
             if not member.guild.voice_channels:
-                print("no vc found") #works for now, expand to notify the user later
+                print('no vc found') #works for now, expand to notify the user later
                 return
             most_pop_vc = member.guild.voice_channels[0]
             for vc in member.guild.voice_channels:
@@ -77,8 +79,8 @@ async def on_voice_state_update(member, before, after):
                     most_pop_vc = vc
             if len(most_pop_vc.members) > 0:
                 await most_pop_vc.connect()
-                print("reconnected to vc")
+                print('reconnected to vc')
             else:
-                print("no active vc")
+                print('no active vc')
 
 bot.run(BOT_TOKEN)

--- a/muted_notification_bot.py
+++ b/muted_notification_bot.py
@@ -13,17 +13,19 @@ FFMPEG_PATH = os.getenv('FFMPEG_PATH')
 DEFAULT_SOUND_PATH = os.getenv('DEFAULT_SOUND_PATH')
 CUSTOM_SOUNDS_PATH = os.getenv('CUSTOM_SOUNDS_PATH')
 
-#custom sound paths for certain Discord members are stored in a .json file
-custom_sounds = json.load(open(os.path.join(os.path.dirname(__file__), CUSTOM_SOUNDS_PATH)))
 intents = discord.Intents.all()
 bot = commands.Bot(command_prefix='!', intents=intents, case_insensitive=False)
+
+#helper function to retrieve path
+def get_path(path):
+    return os.path.join(os.path.dirname(__file__), path)
 
 #play chosen notification sound in voice channel
 async def play(voice_client, member, status):   
     if str(member.id) in custom_sounds:
-        sound_path = os.path.join(os.path.dirname(__file__), custom_sounds[str(member.id)][status])
+        sound_path = get_path(custom_sounds[str(member.id)][status])
     else:
-        sound_path = os.path.join(os.path.dirname(__file__), DEFAULT_SOUND_PATH)
+        sound_path = get_path(DEFAULT_SOUND_PATH)
     audio_source = discord.FFmpegPCMAudio(executable=FFMPEG_PATH, source=sound_path)
     if not voice_client.is_playing():
         voice_client.play(audio_source, after=None)
@@ -93,9 +95,6 @@ async def on_voice_state_update(member, before, after):
         #if bot has just disconnected from a channel, check if any other channels have members and join the most populous
         if not voice_client:
             print('checking for active vc...')
-            if not member.guild.voice_channels:
-                print('no vc found') #works for now, expand to notify the user later
-                return
             most_pop_vc = member.guild.voice_channels[0]
             for vc in member.guild.voice_channels:
                 if len(vc.members) > len(most_pop_vc.members):
@@ -105,5 +104,8 @@ async def on_voice_state_update(member, before, after):
                 print('reconnected to vc')
             else:
                 print('no active vc')
+
+#custom sound paths for certain Discord members are stored in a .json file
+custom_sounds = json.load(open(get_path(CUSTOM_SOUNDS_PATH)))
 
 bot.run(BOT_TOKEN)


### PR DESCRIPTION
Bot now includes the following functionality:
- Automatically joins voice channel once a user has joined
- Automatically leaves voice channel once all users have left
- Automatically moves to the most populous voice channel if users change or leave voice channel
- Plays notification sound in voice channel when user deafens or mutes
- Plays notification sound in voice channel when user joins
- Plays notification sound in voice channel when user leaves
- Supports custom sounds for specific users for each different user action (mute/deafen, join, leave). Sound files are stored locally, with a JSON file storing user IDs and sound paths
- 'Queues' sounds if actions occur while a notification sound is already playing